### PR TITLE
#1316 show available option for selecting redis db

### DIFF
--- a/conf.d/redisdb.yaml.example
+++ b/conf.d/redisdb.yaml.example
@@ -3,6 +3,7 @@ init_config:
 instances:
   - host: localhost
     port: 6379
+    # db: 1 # without this, db 0 is selected
     # unix_socket_path: /var/run/redis/redis.sock # optional, can be used in lieu of host/port
     # password: mypassword
     # tags:


### PR DESCRIPTION
Issue #1316 highlights that an available option isn't provided in the example redis.yaml file. This patch resolves that issue.